### PR TITLE
Fix the problem of loop exit

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -5,7 +5,7 @@ do
   [[ -d "$x" ]] || break
   [[ -f "$x"/Makefile ]] || break
   echo "run test for $x"
-  cd $x && make
+  make -C $x
 done
 
 for x in workloads/*/
@@ -13,5 +13,5 @@ do
   [[ -d "$x" ]] || break
   [[ -f "$x"/Makefile ]] || break
   echo "run test for $x"
-  cd $x && make
+  make -C $x
 done

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -4,7 +4,7 @@ do
   [[ -d "$x" ]] || break
   [[ -f "$x"/Makefile ]] || break
   echo "run test for $x"
-  cd $x && make test
+  make test -C $x
 done
 
 for x in workloads/*/
@@ -12,5 +12,5 @@ do
   [[ -d "$x" ]] || break
   [[ -f "$x"/Makefile ]] || break
   echo "run test for $x"
-  cd $x && make test
+  make test -C $x
 done


### PR DESCRIPTION
Fixes build and test scripts.


build.sh and test.sh cannot meet the loop condition after using cd.