### PR TITLE
[Trait] Move the git module name to match github name

### DIFF
--- a/traits/metricstrait/api/v1alpha1/metricstrait_webhook.go
+++ b/traits/metricstrait/api/v1alpha1/metricstrait_webhook.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -40,7 +41,6 @@ const (
 
 // log is for logging in this package.
 var metricstraitlog = logf.Log.WithName("metricstrait-resource")
-var trueVar = true
 
 // +kubebuilder:webhook:path=/mutate-standard-oam-dev-v1alpha1-metricstrait,mutating=true,failurePolicy=fail,groups=standard.oam.dev,resources=metricstraits,verbs=create;update,versions=v1alpha1,name=mmetricstrait.kb.io
 
@@ -63,7 +63,7 @@ func (r *MetricsTrait) Default() {
 	}
 	if r.Spec.ScrapeService.Enabled == nil {
 		metricstraitlog.Info("default enabled as true")
-		r.Spec.ScrapeService.Enabled = &trueVar
+		r.Spec.ScrapeService.Enabled = pointer.BoolPtr(true)
 	}
 }
 

--- a/traits/metricstrait/controllers/metricstrait_controller.go
+++ b/traits/metricstrait/controllers/metricstrait_controller.go
@@ -36,7 +36,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"metricstrait/api/v1alpha1"
+	"github.com/oam-dev/catalog/traits/metricstrait/api/v1alpha1"
 )
 
 const (

--- a/traits/metricstrait/controllers/metricstrait_controller_integration_test.go
+++ b/traits/metricstrait/controllers/metricstrait_controller_integration_test.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	"metricstrait/api/v1alpha1"
+	"github.com/oam-dev/catalog/traits/metricstrait/api/v1alpha1"
 )
 
 var (
@@ -37,7 +37,6 @@ var _ = Describe("Metrics Trait Integration Test", func() {
 	targetPort := intstr.FromInt(podPort)
 	metricsPath := "/notMetrics"
 	scheme := "http"
-	trueVar := true
 	var ns corev1.Namespace
 	var metricsTraitBase v1alpha1.MetricsTrait
 	var workloadBase appsv1.Deployment

--- a/traits/metricstrait/controllers/metricstrait_webhook_test.go
+++ b/traits/metricstrait/controllers/metricstrait_webhook_test.go
@@ -6,7 +6,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"metricstrait/api/v1alpha1"
+	"github.com/oam-dev/catalog/traits/metricstrait/api/v1alpha1"
 )
 
 var _ = Describe("Metrics Admission controller Test", func() {

--- a/traits/metricstrait/controllers/suite_test.go
+++ b/traits/metricstrait/controllers/suite_test.go
@@ -36,7 +36,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	standardv1alpha1 "metricstrait/api/v1alpha1"
+	standardv1alpha1 "github.com/oam-dev/catalog/traits/metricstrait/api/v1alpha1"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -68,7 +68,7 @@ var _ = BeforeSuite(func(done Done) {
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{
 			filepath.Join("..", "config", "crd", "bases"),
-			filepath.Join("..", "hack/crds"), // this has the OAM CRDs, a bit hacky
+			filepath.Join("..", "hack/crds"), // this has all the required CRDs, a bit hacky
 		},
 	}
 	var err error

--- a/traits/metricstrait/go.mod
+++ b/traits/metricstrait/go.mod
@@ -1,4 +1,4 @@
-module metricstrait
+module github.com/oam-dev/catalog/traits/metricstrait
 
 go 1.13
 
@@ -14,6 +14,7 @@ require (
 	k8s.io/apimachinery v0.18.5
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/kube-openapi v0.0.0-20200410145947-bcb3869e6f29 // indirect
+	k8s.io/utils v0.0.0-20200414100711-2df71ebbae66
 	sigs.k8s.io/controller-runtime v0.6.0
 )
 

--- a/traits/metricstrait/main.go
+++ b/traits/metricstrait/main.go
@@ -28,8 +28,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	standardv1alpha1 "metricstrait/api/v1alpha1"
-	"metricstrait/controllers"
+	standardv1alpha1 "github.com/oam-dev/catalog/traits/metricstrait/api/v1alpha1"
+	"github.com/oam-dev/catalog/traits/metricstrait/controllers"
 	// +kubebuilder:scaffold:imports
 )
 


### PR DESCRIPTION
### Description of your changes
Move the git module name to match github name. The kubebuilder generated module name doesn't match github name


### How has this code been tested?
running UT and integration test

### Checklist

I have:
- [x] Title of the PR starts with OAM type (e.g. `[Workload]` or `[Trait]` or `[Scope]`).
- [ ] Updated/Added any relevant [documentation] and [examples].
- [ ] Unit/E2E Tests added.
