### PR TITLE
Fix CI issue: The `add-path` command is disabled

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -39,6 +39,8 @@ jobs:
 
     - name: Install Helm
       uses: engineerd/configurator@v0.0.1
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
       with:
         name: helm
         url: https://get.helm.sh/helm-v3.1.2-linux-amd64.tar.gz
@@ -46,6 +48,8 @@ jobs:
 
     - name: Setup Kind Cluster
       uses: engineerd/setup-kind@v0.4.0
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
       with:
         version: "v0.7.0"
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,18 +38,14 @@ jobs:
         make test
 
     - name: Install Helm
-      uses: engineerd/configurator@v0.0.1
-      env:
-        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+      uses: engineerd/configurator@v0.0.5
       with:
         name: helm
         url: https://get.helm.sh/helm-v3.1.2-linux-amd64.tar.gz
         pathInArchive: linux-amd64/helm
 
     - name: Setup Kind Cluster
-      uses: engineerd/setup-kind@v0.4.0
-      env:
-        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+      uses: engineerd/setup-kind@v0.5.0
       with:
         version: "v0.7.0"
 


### PR DESCRIPTION
Error: Unable to process command '##[add-path]/home/runner/configurator/bin' successfully.
Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt
into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS`
environment variable to `true`.

To fix issue #67 
