### PR TITLE
hpa trait may econcile before child resource

### DIFF
--- a/traits/hpatrait/controllers/horizontalpodautoscalertrait_controller.go
+++ b/traits/hpatrait/controllers/horizontalpodautoscalertrait_controller.go
@@ -97,7 +97,7 @@ func (r *HorizontalPodAutoscalerTraitReconciler) Reconcile(req ctrl.Request) (ct
 
 	if len(hpas) == 0 {
 		r.Log.Info("Cannot get any HPA-applicable resources")
-		return ctrl.Result{}, util.PatchCondition(ctx, r, &hpatrait, cpv1alpha1.ReconcileError(fmt.Errorf(errLocateAvailableResouces)))
+		return ctrl.ReconcileWaitResult, util.PatchCondition(ctx, r, &hpatrait, cpv1alpha1.ReconcileError(fmt.Errorf(errLocateAvailableResouces)))
 	}
 
 	// to record UID of newly created HPAs

--- a/traits/hpatrait/controllers/horizontalpodautoscalertrait_controller.go
+++ b/traits/hpatrait/controllers/horizontalpodautoscalertrait_controller.go
@@ -97,7 +97,7 @@ func (r *HorizontalPodAutoscalerTraitReconciler) Reconcile(req ctrl.Request) (ct
 
 	if len(hpas) == 0 {
 		r.Log.Info("Cannot get any HPA-applicable resources")
-		return ctrl.ReconcileWaitResult, util.PatchCondition(ctx, r, &hpatrait, cpv1alpha1.ReconcileError(fmt.Errorf(errLocateAvailableResouces)))
+		return ctrl.ReconcileWaitResult, fmt.Errorf(errLocateAvailableResouces)
 	}
 
 	// to record UID of newly created HPAs


### PR DESCRIPTION
due to workload child resource create not timely lead to  not generate hpa, should wait 30s, go on reconciling.

