### PR TITLE
Fix: remove ststoken from stringdata of a secret

### DIFF
--- a/addons/terraform-provider-alibaba/resources/alibaba-account-creds.cue
+++ b/addons/terraform-provider-alibaba/resources/alibaba-account-creds.cue
@@ -10,7 +10,7 @@ output: {
 			namespace: "vela-system"
 		}
 		type: "Opaque"
-		stringData: credentials: strings.Join([creds1, creds2, creds3], "\n")
+		stringData: credentials: strings.Join([creds1, creds2], "\n")
 	}
 }
 


### PR DESCRIPTION
In #132, the defiitions of ststoken is removed, but it wasn't removed
from the stringdata of the secret

<!--
Thank you for contributing to OAM workloads!

-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every OAM catalog pull request.
-->
I have:
- [ ] Title of the PR starts with OAM type (e.g. `[Workload]` or `[Trait]` or `[Scope]`).
- [ ] Updated/Added any relevant [documentation] and [examples].
- [ ] Unit/E2E Tests added.
