### PR TITLE
Fix the parameter `ALICLOUD_REGION` from terraform alibaba addon

### DIFF
--- a/addons/terraform-provider-alibaba/resources/parameter.cue
+++ b/addons/terraform-provider-alibaba/resources/parameter.cue
@@ -1,5 +1,5 @@
 parameter: {
-	ALICLOUD_ACCESS_KEY:     *"" | string
-	ALICLOUD_SECRET_KEY:     *"" | string
-	ALICLOUD_DEFAULT_REGION:      *"" | string
+	ALICLOUD_ACCESS_KEY: *"" | string
+	ALICLOUD_SECRET_KEY: *"" | string
+	ALICLOUD_REGION:     *"" | string
 }


### PR DESCRIPTION
The parameter `ALICLOUD_DEFAULT_REGION` doesn't match the secret key
`ALICLOUD_REGION`

<!--
Thank you for contributing to OAM workloads!

-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every OAM catalog pull request.
-->
I have:
- [ ] Title of the PR starts with OAM type (e.g. `[Workload]` or `[Trait]` or `[Scope]`).
- [ ] Updated/Added any relevant [documentation] and [examples].
- [ ] Unit/E2E Tests added.
