### PR TITLE
Fix properties error for Grafana and Loki in Addon observability

### DIFF
--- a/addons/observability/resources/grafana.cue
+++ b/addons/observability/resources/grafana.cue
@@ -12,10 +12,11 @@ output: {
 	traits: [
 		{
 			type: "pure-ingress"
-			properties:
+			properties: {
 				domain: parameter["grafana-domain"]
-			http:
-				"/": 80
+				http:
+					"/": 80
+			}
 		},
 		{
 			type: "import-grafana-dashboard"

--- a/addons/observability/resources/loki.cue
+++ b/addons/observability/resources/loki.cue
@@ -12,15 +12,16 @@ output: {
 	}
 	traits: [{
 		type: "register-grafana-datasource" // register loki datasource to Grafana
-		properties:
-			grafanaServiceName: "grafana"
-		grafanaServiceNamespace:   "observability"
-		credentialSecret:          "grafana"
-		credentialSecretNamespace: "observability"
-		name:                      "loki"
-		service:                   "loki"
-		namespace:                 "observability"
-		type:                      "loki"
-		access:                    "proxy"
+		properties: {
+			grafanaServiceName:        "grafana"
+			grafanaServiceNamespace:   "observability"
+			credentialSecret:          "grafana"
+			credentialSecretNamespace: "observability"
+			name:                      "loki"
+			service:                   "loki"
+			namespace:                 "observability"
+			type:                      "loki"
+			access:                    "proxy"
+		}
 	}]
 }


### PR DESCRIPTION
More than one properties are not coupled with {}, which leads to the
renderring error for components and traits

<!--
Thank you for contributing to OAM workloads!

-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every OAM catalog pull request.
-->
I have:
- [ ] Title of the PR starts with OAM type (e.g. `[Workload]` or `[Trait]` or `[Scope]`).
- [ ] Updated/Added any relevant [documentation] and [examples].
- [ ] Unit/E2E Tests added.
