### PR TITLE
Correct .cue for kube-state-metrics component

### DIFF
--- a/addons/observability/resources/kube-state-metrics.cue
+++ b/addons/observability/resources/kube-state-metrics.cue
@@ -1,5 +1,5 @@
 output: {
-	type: helm
+	type: "helm"
 	properties: {
 		chart:    "kube-state-metrics"
 		version:  "3.4.1"

--- a/addons/observability/resources/kube-state-metrics.cue
+++ b/addons/observability/resources/kube-state-metrics.cue
@@ -1,15 +1,17 @@
-type: helm
-properties: {
-	chart:    "kube-state-metrics"
-	version:  "3.4.1"
-	repoType: "helm"
-	// original url: https://prometheus-community.github.io/helm-charts
-	url:             "https://charts.kubevela.net/addons"
-	targetNamespace: "vela-system"
-	values: {
-		image: {
-			repository: "oamdev/kube-state-metrics"
-			tag:        "v2.1.0"
+output: {
+	type: helm
+	properties: {
+		chart:    "kube-state-metrics"
+		version:  "3.4.1"
+		repoType: "helm"
+		// original url: https://prometheus-community.github.io/helm-charts
+		url:             "https://charts.kubevela.net/addons"
+		targetNamespace: "vela-system"
+		values: {
+			image: {
+				repository: "oamdev/kube-state-metrics"
+				tag:        "v2.1.0"
+			}
 		}
 	}
 }


### PR DESCRIPTION
The component kube-state-metrics in .cue format is wrong, which leads
to the failure of rendering

<!--
Thank you for contributing to OAM workloads!

-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every OAM catalog pull request.
-->
I have:
- [ ] Title of the PR starts with OAM type (e.g. `[Workload]` or `[Trait]` or `[Scope]`).
- [ ] Updated/Added any relevant [documentation] and [examples].
- [ ] Unit/E2E Tests added.
