### PR TITLE
[Addon] Increase helm install timeout to 10min, add parameter

### DIFF
--- a/addons/fluxcd/definitions/helm-release-def.yaml
+++ b/addons/fluxcd/definitions/helm-release-def.yaml
@@ -57,6 +57,7 @@ spec:
         		name: context.name
         	}
         	spec: {
+        		timeout: parameter.installTimeout
         		interval: parameter.pullInterval
         		chart: {
         			spec: {
@@ -115,6 +116,8 @@ spec:
         	secretRef?: string
         	// +usage=The timeout for operations like download index/clone repository, optional
         	timeout?: string
+        	// +usage=The timeout for operation `helm install`, optional
+        	installTimeout: *"10m" | string
 
         	git?: {
         		// +usage=The Git reference to checkout and monitor for changes, defaults to master branch


### PR DESCRIPTION
<!--
Thank you for contributing to OAM workloads!

-->


### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

Add helm install timeout paramter. This parameter default to 10m. Default value is 5m when not configured.
ref doc https://fluxcd.io/docs/components/helm/helmreleases/#specification

Fixes https://github.com/oam-dev/kubevela/issues/2729

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every OAM catalog pull request.
-->
I have:
- [x] Title of the PR starts with OAM type (e.g. `[Workload]` or `[Trait]` or `[Scope]`).
- [ ] Updated/Added any relevant [documentation] and [examples].
- [ ] Unit/E2E Tests added.
