### PR TITLE
Fix: change the namespace of Grafana

### DIFF
--- a/addons/observability/resources/grafana.cue
+++ b/addons/observability/resources/grafana.cue
@@ -22,9 +22,9 @@ output: {
 			type: "import-grafana-dashboard"
 			properties: {
 				grafanaServiceName:        "grafana"
-				grafanaServiceNamespace:   "observability"
+				grafanaServiceNamespace:   "vela-system"
 				credentialSecret:          "grafana"
-				credentialSecretNamespace: "observability"
+				credentialSecretNamespace: "vela-system"
 				urls: [
 					"https://charts.kubevela.net/addons/dashboards/kubevela_core_logging.json",
 					"https://charts.kubevela.net/addons/dashboards/kubevela_core_monitoring.json",


### PR DESCRIPTION
The namespace of Grafana should also be in vela-system

<!--
Thank you for contributing to OAM workloads!

-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every OAM catalog pull request.
-->
I have:
- [ ] Title of the PR starts with OAM type (e.g. `[Workload]` or `[Trait]` or `[Scope]`).
- [ ] Updated/Added any relevant [documentation] and [examples].
- [ ] Unit/E2E Tests added.
