### PR TITLE
Reduce the parameters for Add-on Observability

### DIFF
--- a/addons/observability/resources/parameter.cue
+++ b/addons/observability/resources/parameter.cue
@@ -1,11 +1,3 @@
 parameter: {
 	"grafana-domain":           *"" | string
-
-	"alertmanager-pvc-enabled": *true | bool
-	"alertmanager-pvc-class":   *"" | string
-	"alertmanager-pvc-size":    *"20Gi" | string
-
-	"server-pvc-enabled": *true | bool
-	"server-pvc-class":   *"" | string
-	"server-pvc-size":    *"20Gi" | string
 }

--- a/addons/observability/resources/prometheus-server.cue
+++ b/addons/observability/resources/prometheus-server.cue
@@ -9,18 +9,6 @@ output: {
 		url:             "https://charts.kubevela.net/addons"
 		targetNamespace: "vela-system"
 		releaseName:     "prometheus"
-		values: {
-			alertmanager: persistentVolume: {
-				enabled:      parameter["alertmanager-pvc-enabled"]
-				storageClass: parameter["alertmanager-pvc-class"]
-				size:         parameter["alertmanager-pvc-size"]
-			}
-			server: persistentVolume: {
-				enabled:      parameter["server-pvc-enabled"]
-				storageClass: parameter["server-pvc-class"]
-				size:         parameter["server-pvc-size"]
-			}
-		}
 	}
 	traits: [
 		{


### PR DESCRIPTION
Users doesn't need to set pvc name and size for Prometheus alarm
and server. But have to set a default stroage class for a Kubernetes
Cluster.

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>

<!--
Thank you for contributing to OAM workloads!

-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every OAM catalog pull request.
-->
I have:
- [ ] Title of the PR starts with OAM type (e.g. `[Workload]` or `[Trait]` or `[Scope]`).
- [ ] Updated/Added any relevant [documentation] and [examples].
- [ ] Unit/E2E Tests added.
