### PR TITLE
Observability add-on needs to customize runtime

### DIFF
--- a/addons/observability/metadata.yaml
+++ b/addons/observability/metadata.yaml
@@ -7,7 +7,9 @@ tags:
 
 deployTo:
   control_plane: true
-  runtime_cluster: false
+  runtime_cluster: true
+  customize_runtime_cluster: true
+
 
 dependencies:
 - name: fluxcd


### PR DESCRIPTION
Use `deployTo.customize_runtime_cluster` in add-on metadata
to mark it will need to customize runtime clusters to enable
the addon

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>

<!--
Thank you for contributing to OAM workloads!

-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every OAM catalog pull request.
-->
I have:
- [ ] Title of the PR starts with OAM type (e.g. `[Workload]` or `[Trait]` or `[Scope]`).
- [ ] Updated/Added any relevant [documentation] and [examples].
- [ ] Unit/E2E Tests added.
