### PR TITLE
Feat: change velaux default version to v1.2.0-beta.2

### DIFF
--- a/addons/velaux/resources/parameter.cue
+++ b/addons/velaux/resources/parameter.cue
@@ -1,6 +1,6 @@
 parameter: {
 	// +usage=Specify the version of velaux.
-	version: *"v1.2.0-beta.1" | string
+	version: *"v1.2.0-beta.2" | string
 	// +usage=Specify the image hub of velaux, eg. "acr.kubevela.net"
 	repo?: string
 	// +usage=Specify the database type, current support KubeAPI(default) and MongoDB.


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>
