### PR TITLE
[addon] Upgrade terraform addon

### DIFF
--- a/addons/terraform/template.yaml
+++ b/addons/terraform/template.yaml
@@ -26,5 +26,5 @@ spec:
         repoType: helm
         url: https://charts.kubevela.net/addons
         chart: terraform-controller
-        version: 0.2.11
+        version: 0.2.13
 


### PR DESCRIPTION
- Fix unproper serviceaccount settings
When there are two applications, who have the same application name, but
different namespace names, the second one's service account will use
the first one. But the clusterrole's namespace isn't in its namespace.
It will lack all authority to perform any operations when running
Terraform applying.

- Support validating stsToken
Besides validating ak/sk, support stsToken

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>

<!--
Thank you for contributing to OAM workloads!

-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every OAM catalog pull request.
-->
I have:
- [ ] Title of the PR starts with OAM type (e.g. `[Workload]` or `[Trait]` or `[Scope]`).
- [ ] Updated/Added any relevant [documentation] and [examples].
- [ ] Unit/E2E Tests added.
