### PR TITLE
Don't repeat the description for two parameters

### DIFF
--- a/addons/terraform-alibaba/resources/parameter.cue
+++ b/addons/terraform-alibaba/resources/parameter.cue
@@ -1,7 +1,7 @@
 parameter: {
-	//+usage=Get ALICLOUD_ACCESS_KEY and ALICLOUD_SECRET_KEY per this guide https://help.aliyun.com/knowledge_detail/38738.html
+	//+usage=Get ALICLOUD_ACCESS_KEY per this guide https://help.aliyun.com/knowledge_detail/38738.html
 	ALICLOUD_ACCESS_KEY: *"" | string
-	//+usage=Get ALICLOUD_ACCESS_KEY and ALICLOUD_SECRET_KEY per this guide https://help.aliyun.com/knowledge_detail/38738.html
+	//+usage=Get ALICLOUD_SECRET_KEY per this guide https://help.aliyun.com/knowledge_detail/38738.html
 	ALICLOUD_SECRET_KEY: *"" | string
 	//+usage=Get ALICLOUD_REGION by picking one RegionId from Alibaba Cloud region list https://www.alibabacloud.com/help/doc-detail/72379.htm
 	ALICLOUD_REGION:     *"" | string


### PR DESCRIPTION
Make the way of setting parameters ALICLOUD_ACCESS_KEY and
ALICLOUD_SECRET_KEY in different descriptions.

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>

<!--
Thank you for contributing to OAM workloads!

-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every OAM catalog pull request.
-->
I have:
- [ ] Title of the PR starts with OAM type (e.g. `[Workload]` or `[Trait]` or `[Scope]`).
- [ ] Updated/Added any relevant [documentation] and [examples].
- [ ] Unit/E2E Tests added.
