### PR TITLE
Add dependson in Addon observability to ensure deletion order

### DIFF
--- a/addons/observability/resources/prometheus-server.cue
+++ b/addons/observability/resources/prometheus-server.cue
@@ -1,6 +1,7 @@
 // install Prometheus
 output: {
 	type: "helm"
+	dependsOn: ["grafana-registration"]
 	properties: {
 		chart:    "prometheus"
 		version:  "14.4.1"

--- a/addons/observability/template.yaml
+++ b/addons/observability/template.yaml
@@ -20,6 +20,8 @@ spec:
     # install loki
     - name: loki
       type: helm
+      dependsOn:
+        - grafana-registration
       properties:
         chart: loki-stack
         version: 2.4.1


### PR DESCRIPTION
Added the dependency of grafana-registration for component
loki and prometheus-server to ensure the appended traits are deleted
before grafana-registration is deleted.

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>

<!--
Thank you for contributing to OAM workloads!

-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every OAM catalog pull request.
-->
I have:
- [ ] Title of the PR starts with OAM type (e.g. `[Workload]` or `[Trait]` or `[Scope]`).
- [ ] Updated/Added any relevant [documentation] and [examples].
- [ ] Unit/E2E Tests added.
