### PR TITLE
Fix: mocker server have some chance to startup failed

### DIFF
--- a/.github/workflows/addon-test.yaml
+++ b/.github/workflows/addon-test.yaml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ master ]
 
+env:
+  # Common versions
+  GO_VERSION: '1.16'
+
 
 jobs:
 
@@ -31,11 +35,10 @@ jobs:
 
     steps:
 
-      - name: Set up Go 1.13
-        uses: actions/setup-go@v1
+      - name: Setup Go
+        uses: actions/setup-go@v2
         with:
-          go-version: 1.13
-        id: go
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -22,5 +22,5 @@ standard-autoscaler-test:
 addon-test:
 	cp -r addons/ test/e2e-test/addon/testdata/
 	cd test/e2e-test/addon/ && \
-	   go run mock_server.go && sleep 3 &
+	   go run mock_server.go &
 	bash ./test/e2e-test/hack/addon-vela-test.sh

--- a/test/e2e-test/addon/mock_server.go
+++ b/test/e2e-test/addon/mock_server.go
@@ -96,6 +96,7 @@ func main() {
 	if err != nil {
 		log.Fatal("Apply mock server config to ConfigMap fail")
 	}
+	log.Println("modify Configmap succeed, ready to startup mock server")
 	http.HandleFunc("/", ossHandler)
 	err = http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
 	if err != nil {

--- a/test/e2e-test/hack/addon-vela-test.sh
+++ b/test/e2e-test/hack/addon-vela-test.sh
@@ -1,6 +1,23 @@
 #!/bin/sh
 
-ADDONS=`vela addon list |awk 'NR>1'|awk '{print $1}'`
+STARTUP=0
+
+for i in {1..300} ; do
+  curl 127.0.0.1:19098 > /dev/null 2>&1
+  if [ $? == 0 ]; then
+      STARTUP=1
+      break
+     else
+       sleep 1
+  fi
+done
+
+if [ $STARTUP -eq 0  ]; then
+  echo server not startup
+  exit 1
+fi
+
+ADDONS=`vela addon list |awk 'NR>1'|awk '{print $1}'` | sort
 
 vela addon list
 


### PR DESCRIPTION
The e2e test should curl the mock server ip to wait until the server startup acctually.

<!--
Thank you for contributing to OAM workloads!

-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every OAM catalog pull request.
-->
I have:
- [ ] Title of the PR starts with OAM type (e.g. `[Workload]` or `[Trait]` or `[Scope]`).
- [ ] Updated/Added any relevant [documentation] and [examples].
- [ ] Unit/E2E Tests added.
