### PR TITLE
[Addon] Support use to choose whether speed up Github

### DIFF
--- a/addons/terraform/metadata.yaml
+++ b/addons/terraform/metadata.yaml
@@ -2,7 +2,7 @@ name: terraform
 version: 1.0.0
 description: Terraform Controller is a Kubernetes Controller for Terraform.
 icon: https://www.terraform.io/assets/images/logo-text-8c3ba8a6.svg
-url: https://terraform.io/
+url: https://github.com/oam-dev/terraform-controller
 
 tags:
   - IaC

--- a/addons/terraform/resources/parameter.cue
+++ b/addons/terraform/resources/parameter.cue
@@ -1,4 +1,4 @@
 parameter: {
 	// +usage=Whether GitHub is blocked
-	"github-blocked": *false | bool
+	"githubBlocked": *false | bool
 }

--- a/addons/terraform/resources/parameter.cue
+++ b/addons/terraform/resources/parameter.cue
@@ -1,0 +1,4 @@
+parameter: {
+	// +usage=Whether GitHub is blocked
+	"github-blocked": *false | bool
+}

--- a/addons/terraform/resources/terraform-controller.cue
+++ b/addons/terraform/resources/terraform-controller.cue
@@ -4,9 +4,14 @@ output: {
 		repoType: "helm"
 		url:      "https://charts.kubevela.net/addons"
 		chart:    "terraform-controller"
-		version:  "0.2.15"
+		version:  "0.2.20"
 		values: {
-			githubBlocked: parameter["github-blocked"]
+			if !parameter["githubBlocked"] {
+				githubBlocked: "'false'"
+			}
+			if parameter["githubBlocked"] {
+				githubBlocked: "'true'"
+			}
 		}
 	}
 }

--- a/addons/terraform/resources/terraform-controller.cue
+++ b/addons/terraform/resources/terraform-controller.cue
@@ -1,0 +1,12 @@
+output: {
+	type: "helm"
+	properties: {
+		repoType: "helm"
+		url:      "https://charts.kubevela.net/addons"
+		chart:    "terraform-controller"
+		version:  "0.2.15"
+		values: {
+			githubBlocked: parameter["github-blocked"]
+		}
+	}
+}

--- a/addons/terraform/template.yaml
+++ b/addons/terraform/template.yaml
@@ -4,26 +4,3 @@ metadata:
   name: terraform
   namespace: vela-system
 spec:
-  workflow:
-    steps:
-      - name: apply-ns
-        type: apply-component
-        properties:
-          component: ns-terraform-system
-      - name: apply-resources
-        type: apply-remaining
-  components:
-    - name: ns-terraform-system
-      type: raw
-      properties:
-        apiVersion: v1
-        kind: Namespace
-        metadata:
-          name: terraform-system
-    - name: terraform-controller
-      type: helm
-      properties:
-        repoType: helm
-        url: https://charts.kubevela.net/addons
-        chart: terraform-controller
-        version: 0.2.14


### PR DESCRIPTION
Added a parameter `github-blocked` for Addon Terraform to decide
whether to replace Github to Gitee where Terraform modules are stored.

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>

<!--
Thank you for contributing to OAM workloads!

-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every OAM catalog pull request.
-->
I have:
- [ ] Title of the PR starts with OAM type (e.g. `[Workload]` or `[Trait]` or `[Scope]`).
- [ ] Updated/Added any relevant [documentation] and [examples].
- [ ] Unit/E2E Tests added.
