### PR TITLE
[Addon] Fix the description of addon velaux

### DIFF
--- a/addons/velaux/metadata.yaml
+++ b/addons/velaux/metadata.yaml
@@ -1,6 +1,6 @@
 name: velaux
 version: 1.2.0
-description: The KubeVela User Experience (UX ). Dashboard Designed as an extensible, application-oriented delivery and management control panel.
+description: KubeVela User Experience (UX). An extensible, application-oriented delivery and management Dashboard.
 icon: https://static.kubevela.net/images/logos/KubeVela%20-03.png
 url: https://kubevela.io
 


### PR DESCRIPTION
The description of addon velaux contains an extra blank character
and is too long

Fix #224

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>

<!--
Thank you for contributing to OAM workloads!

-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every OAM catalog pull request.
-->
I have:
- [ ] Title of the PR starts with OAM type (e.g. `[Workload]` or `[Trait]` or `[Scope]`).
- [ ] Updated/Added any relevant [documentation] and [examples].
- [ ] Unit/E2E Tests added.
