### PR TITLE
Feat: add imagePullSecrets for addon velaux to pull images from private registry

### DIFF
--- a/addons/velaux/resources/apiserver.cue
+++ b/addons/velaux/resources/apiserver.cue
@@ -1,5 +1,3 @@
-import "encoding/json"
-
 database: *[if parameter["database"] != _|_ {
 "--datastore-database=" + parameter["database"]
 }] | []
@@ -20,7 +18,7 @@ output: {
 		}
 
 		if parameter["imagePullSecrets"] != _|_ {
-			imagePullSecrets: json.Unmarshal(parameter["imagePullSecrets"])
+			imagePullSecrets: parameter["imagePullSecrets"]
 		}
 
 		cmd: ["apiserver", "--datastore-type=" + parameter["dbType"]] + database + dbURL

--- a/addons/velaux/resources/apiserver.cue
+++ b/addons/velaux/resources/apiserver.cue
@@ -1,3 +1,5 @@
+import "encoding/json"
+
 database: *[if parameter["database"] != _|_ {
 "--datastore-database=" + parameter["database"]
 }] | []
@@ -15,6 +17,10 @@ output: {
 
 		if parameter["repo"] != _|_ {
 			image: parameter["repo"] + "/" +"oamdev/vela-apiserver:" + parameter["version"]
+		}
+
+		if parameter["imagePullSecrets"] != _|_ {
+			imagePullSecrets: json.Unmarshal(parameter["imagePullSecrets"])
 		}
 
 		cmd: ["apiserver", "--datastore-type=" + parameter["dbType"]] + database + dbURL

--- a/addons/velaux/resources/parameter.cue
+++ b/addons/velaux/resources/parameter.cue
@@ -15,6 +15,6 @@ parameter: {
 	serviceAccountName: *"kubevela-vela-core" | string
 	// +usage=Specify the service type.
 	serviceType: *"ClusterIP" | "NodePort" | "LoadBalancer" | "ExternalName"
-	// +usage=Specify the imagePullSecrets for private image registry, eg. " ["regcred"] "
-	imagePullSecrets?: string
+	// +usage=Specify the names of imagePullSecret for private image registry, eg. "{a,b,c}"
+	imagePullSecrets?: [...string]
 }

--- a/addons/velaux/resources/parameter.cue
+++ b/addons/velaux/resources/parameter.cue
@@ -15,4 +15,6 @@ parameter: {
 	serviceAccountName: *"kubevela-vela-core" | string
 	// +usage=Specify the service type.
 	serviceType: *"ClusterIP" | "NodePort" | "LoadBalancer" | "ExternalName"
+	// +usage=Specify the imagePullSecrets for private image registry, eg. " ["regcred"] "
+	imagePullSecrets?: string
 }

--- a/addons/velaux/resources/velaux.cue
+++ b/addons/velaux/resources/velaux.cue
@@ -1,3 +1,5 @@
+import "encoding/json"
+
 output: {
 	type: "webservice"
 	properties: {
@@ -7,6 +9,10 @@ output: {
 
 		if parameter["repo"] != _|_ {
 			image: parameter["repo"] + "/" + "oamdev/velaux:" + parameter["version"]
+		}
+
+		if parameter["imagePullSecrets"] != _|_ {
+			imagePullSecrets: json.Unmarshal(parameter["imagePullSecrets"])
 		}
 
 		ports: [

--- a/addons/velaux/resources/velaux.cue
+++ b/addons/velaux/resources/velaux.cue
@@ -1,5 +1,3 @@
-import "encoding/json"
-
 output: {
 	type: "webservice"
 	properties: {
@@ -12,7 +10,7 @@ output: {
 		}
 
 		if parameter["imagePullSecrets"] != _|_ {
-			imagePullSecrets: json.Unmarshal(parameter["imagePullSecrets"])
+			imagePullSecrets: parameter["imagePullSecrets"]
 		}
 
 		ports: [

--- a/addons/velaux/schemas/addon-uischema-velaux.yaml
+++ b/addons/velaux/schemas/addon-uischema-velaux.yaml
@@ -14,4 +14,3 @@
     defaultValue: kubevela
 - jsonKey: domain
   sort: 9
-


### PR DESCRIPTION
add imagePullSecrets for addon velaux to pull images from private registry

<!--
Thank you for contributing to OAM workloads!

-->

### Description of your changes
When install addon velaux, user could specify customized image registry like this
`vela addon enable velaux serviceType=NodePort repo=acr.kubevela.net`
but usually, the private image registry needs authentication, and Pods need k8s secret to pull images from private image registry.
This patch allows user to  provide k8s secret and let velaux can be installed with private image registry as below:
`vela addon enable velaux serviceType=NodePort  repo=hub.myregistry.com imagePullSecrets="[\"regcred\"]" `



### How has this code been tested?
setup one private registry with Harbor, and assume the private Harbor registry is "hub.myregistry.com", username is "myname", password is "mypass", and secret name is "regcred"

1. install kebevela core and vela cli
2. create secret
'kubectl create secret docker-registry regcred --docker-server=hub.myregistry.com  --docker-username=myname  --docker-password=mypass-n vela-system'
3. enable addon velaux locally

```
cd addons
vela addon enable ./velaux serviceType=NodePort  repo=hub.myregistry.com imagePullSecrets="[\"regcred\"]"  

``` 
4. check status of velaux, all pods should be running
5. check pods of apiserver and velaux, "spec.containers.image" should be fullfilled with private images,
6. check pods of apiserver and velaux, "spec.imagePullSecrets" should be regcred




### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every OAM catalog pull request.
-->
I have:
- [ ] Title of the PR starts with OAM type (e.g. `[Workload]` or `[Trait]` or `[Scope]`).
- [ ] Updated/Added any relevant [documentation] and [examples].
- [ ] Unit/E2E Tests added.
