### PR TITLE
[Addon] Make grafana's service type configurable in addon

### DIFF
--- a/experimental/addons/observability/resources/grafana.cue
+++ b/experimental/addons/observability/resources/grafana.cue
@@ -10,7 +10,7 @@ output: {
 		releaseName:     "grafana"
 		values: {
 			service: {
-				type: "LoadBalancer"
+				type: parameter["serviceType"]
 			}
 		}
 	}

--- a/experimental/addons/observability/resources/parameter.cue
+++ b/experimental/addons/observability/resources/parameter.cue
@@ -1,4 +1,6 @@
 parameter: {
 	// +usage=The size of disk used by Prometheus alart manager and Prometheus server, The unit is GB.
 	"disk-size": *"20" | string
+	// +usage=Specify the service type.
+	serviceType: *"ClusterIP" | "NodePort" | "LoadBalancer"
 }


### PR DESCRIPTION
Signed-off-by: zhukunshuai <jookunshuai@gmail.com>

<!--
Thank you for contributing to OAM workloads!

-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes 
-->

Fixes https://github.com/oam-dev/kubevela/issues/3188
### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every OAM catalog pull request.
-->
I have:
- [ ] Title of the PR starts with OAM type (e.g. `[Workload]` or `[Trait]` or `[Scope]`).
- [ ] Updated/Added any relevant [documentation] and [examples].
- [ ] Unit/E2E Tests added.
