### PR TITLE
Fix: helm release  status upadete slow problem and log error

### DIFF
--- a/addons/fluxcd/definitions/helm-release-def.yaml
+++ b/addons/fluxcd/definitions/helm-release-def.yaml
@@ -109,8 +109,8 @@ spec:
         	repoType: *"helm" | "git" | "oss"
         	// +usage=The interval at which to check for repository/bucket and relese updates, default to 5m
         	pullInterval: *"5m" | string
-            // +usage=The  Interval at which to reconcile the Helm release, default to 30s
-            interval: *"30s" | string
+                // +usage=The  Interval at which to reconcile the Helm release, default to 30s
+                interval: *"30s" | string
         	// +usage=The Git or Helm repository URL, OSS endpoint, accept HTTP/S or SSH address as git url,
         	url: string
         	// +usage=The name of the secret containing authentication credentials

--- a/addons/fluxcd/definitions/helm-release-def.yaml
+++ b/addons/fluxcd/definitions/helm-release-def.yaml
@@ -75,7 +75,7 @@ spec:
         					}
         					name:      context.name
         				}
-        				interval: parameter.pullInterval
+        				interval: parameter.interval
         			}
         		}
         		if parameter.targetNamespace != _|_ {
@@ -109,6 +109,8 @@ spec:
         	repoType: *"helm" | "git" | "oss"
         	// +usage=The interval at which to check for repository/bucket and relese updates, default to 5m
         	pullInterval: *"5m" | string
+            // +usage=The  Interval at which to reconcile the Helm release, default to 30s
+            interval: *"30s" | string
         	// +usage=The Git or Helm repository URL, OSS endpoint, accept HTTP/S or SSH address as git url,
         	url: string
         	// +usage=The name of the secret containing authentication credentials

--- a/addons/fluxcd/resources/deployment/helm-controller.yaml
+++ b/addons/fluxcd/resources/deployment/helm-controller.yaml
@@ -21,7 +21,6 @@ spec:
     spec:
       containers:
         - args:
-            - --events-addr=http://notification-controller/
             - --watch-all-namespaces
             - --log-level=info
             - --log-encoding=json


### PR DESCRIPTION
1. speed up helm release update status

We used fluxcd parameter wrongly before. We use helmRepo pull interval which is helm chart update interval as  helmRelease reconcile the default value is 5min .This due to helm release take a long time after all pods have ready. So introduce a new parameter `interval` as reconcile interval.
 
2. solve helm controller error log abort notification. This is because we have reduce notification controller before.



<!--
Thank you for contributing to OAM workloads!

-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every OAM catalog pull request.
-->
I have:
- [ ] Title of the PR starts with OAM type (e.g. `[Workload]` or `[Trait]` or `[Scope]`).
- [ ] Updated/Added any relevant [documentation] and [examples].
- [ ] Unit/E2E Tests added.
