### PR TITLE
Fix the issue of provisioning aws s3

### DIFF
--- a/addons/terraform-aws/definitions/terraform-aws-s3.yaml
+++ b/addons/terraform-aws/definitions/terraform-aws-s3.yaml
@@ -15,25 +15,32 @@ spec:
   schematic:
     terraform:
       configuration: |
+        terraform {
+          required_providers {
+            aws = {
+              source = "hashicorp/aws"
+              version = "3.74.3"
+            }
+          }
+        }
+
         resource "aws_s3_bucket" "bucket-acl" {
           bucket = var.bucket
           acl    = var.acl
         }
-
         output "BUCKET_NAME" {
+          description = "Bucket name"
           value = aws_s3_bucket.bucket-acl.bucket_domain_name
         }
-
         variable "bucket" {
           description = "S3 bucket name"
-          default = "vela-website"
-          type = string
+          default     = "vela-website-202202241415"
+          type        = string
         }
-
         variable "acl" {
           description = "S3 bucket ACL"
-          default = "private"
-          type = string
+          default     = "private"
+          type        = string
         }
 
       providerRef:

--- a/addons/terraform-aws/definitions/terraform-aws-s3.yaml
+++ b/addons/terraform-aws/definitions/terraform-aws-s3.yaml
@@ -34,7 +34,6 @@ spec:
         }
         variable "bucket" {
           description = "S3 bucket name"
-          default     = "vela-website-202202241415"
           type        = string
         }
         variable "acl" {


### PR DESCRIPTION
AWS Terraform made a break change of setting acl for s3 in version 4.0 https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#using-acl-policy-grants.
Fix https://github.com/oam-dev/kubevela/issues/3327

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>

<!--
Thank you for contributing to OAM workloads!

-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every OAM catalog pull request.
-->
I have:
- [ ] Title of the PR starts with OAM type (e.g. `[Workload]` or `[Trait]` or `[Scope]`).
- [ ] Updated/Added any relevant [documentation] and [examples].
- [ ] Unit/E2E Tests added.
