### PR TITLE
Fix:  fix  addon test ci 

### DIFF
--- a/test/e2e-test/hack/addon-vela-test.sh
+++ b/test/e2e-test/hack/addon-vela-test.sh
@@ -7,7 +7,7 @@ for i in $ADDONS ; do
     if [ $i == "observability" ]; then
       vela addon enable $i domain=abc.com
       else
-      vela addon enable $i
+      vela addon enable ./addons/$i
     fi
 
     if [ $? -ne 0 ]; then


### PR DESCRIPTION
The CI test have been modified wrongly by #253 . The addon test is pull addon files from OSS addon registry. This pr fix this issue.

<!--
Thank you for contributing to OAM workloads!

-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every OAM catalog pull request.
-->
I have:
- [ ] Title of the PR starts with OAM type (e.g. `[Workload]` or `[Trait]` or `[Scope]`).
- [ ] Updated/Added any relevant [documentation] and [examples].
- [ ] Unit/E2E Tests added.
