### PR TITLE
disable fluxcd

### DIFF
--- a/addons/fluxcd/schemas/component-uischema-helm.yaml
+++ b/addons/fluxcd/schemas/component-uischema-helm.yaml
@@ -18,6 +18,7 @@
   sort: 6
   label: OSS
   description: oss repoType detail configuration
+  disable: true
 - jsonKey: values
   uiType: HelmValues
   sort: 7


### PR DESCRIPTION
since fluxcd  don't  support public bucket yet. Let user config AK/SK for public helm chart is a bad UX. So disable oss option firstly. Refer to: https://github.com/fluxcd/source-controller/issues/608


Signed-off-by: 楚岳 <wangyike.wyk@alibaba-inc.com>

<!--
Thank you for contributing to OAM workloads!

-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?

<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist

<!--
Please run through the below readiness checklist. The first two items are
relevant to every OAM catalog pull request.
-->

I have:

- [ ] Title of the PR starts with type (e.g. `[Addon]` or `[Trait]`).
- [ ] Updated/Added any relevant [documentation] and [examples].
- [ ] Unit/E2E Tests added.
