### PR TITLE
Remove dependency of addon terraform

### DIFF
--- a/addons/terraform/metadata.yaml
+++ b/addons/terraform/metadata.yaml
@@ -16,6 +16,3 @@ dependencies:
   - name: fluxcd
 
 invisible: false
-
-system:
-  vela: ">=v1.3.0-alpha.1"


### PR DESCRIPTION
The dependency mechanism of addons cloud not enable users to choose a
specified version of an addon

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>

<!--
Thank you for contributing to OAM workloads!

-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?

<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist

<!--
Please run through the below readiness checklist. The first two items are
relevant to every OAM catalog pull request.
-->

I have:

- [ ] Title of the PR starts with type (e.g. `[Addon]` or `[Trait]`).
- [ ] Updated/Added any relevant [documentation] and [examples].
- [ ] Unit/E2E Tests added.
