### PR TITLE
Hide Terraform provider name in VelaUX

### DIFF
--- a/addons/terraform-alibaba/schemas/component-uischema-terraform-alibaba.yaml
+++ b/addons/terraform-alibaba/schemas/component-uischema-terraform-alibaba.yaml
@@ -1,0 +1,2 @@
+- jsonKey: name
+  disable: true

--- a/addons/terraform-aws/definitions/aws-provider.cue
+++ b/addons/terraform-aws/definitions/aws-provider.cue
@@ -63,10 +63,14 @@ template: {
 
 	parameter: {
 		//+usage=The name of Terraform Provider for AWS, default is `default`
-		name:                  *"aws" | string
-		AWS_ACCESS_KEY_ID:     string
+		name: *"aws" | string
+		//+usage=Get AWS_ACCESS_KEY_ID per https://aws.amazon.com/blogs/security/wheres-my-secret-access-key/
+		AWS_ACCESS_KEY_ID: string
+		//+usage=Get AWS_SECRET_ACCESS_KEY per https://aws.amazon.com/blogs/security/wheres-my-secret-access-key/
 		AWS_SECRET_ACCESS_KEY: string
-		AWS_SESSION_TOKEN:     *"" | string
-		AWS_DEFAULT_REGION:    string
+		//+usage=Get AWS_SESSION_TOKEN per https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html
+		AWS_SESSION_TOKEN: *"" | string
+		//+usage=Choose one of Code form region list https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions
+		AWS_DEFAULT_REGION: string
 	}
 }

--- a/addons/terraform-aws/schemas/component-uischema-terraform-aws.yaml
+++ b/addons/terraform-aws/schemas/component-uischema-terraform-aws.yaml
@@ -1,0 +1,2 @@
+- jsonKey: name
+  disable: true

--- a/addons/terraform-azure/schemas/component-uischema-terraform-azure.yaml
+++ b/addons/terraform-azure/schemas/component-uischema-terraform-azure.yaml
@@ -1,0 +1,2 @@
+- jsonKey: name
+  disable: true

--- a/addons/terraform-baidu/schemas/component-uischema-terraform-baidu.yaml
+++ b/addons/terraform-baidu/schemas/component-uischema-terraform-baidu.yaml
@@ -1,0 +1,2 @@
+- jsonKey: name
+  disable: true

--- a/addons/terraform-gcp/schemas/component-uischema-terraform-gcp.yaml
+++ b/addons/terraform-gcp/schemas/component-uischema-terraform-gcp.yaml
@@ -1,0 +1,2 @@
+- jsonKey: name
+  disable: true

--- a/addons/terraform-tencent/schemas/component-uischema-terraform-tencent.yaml
+++ b/addons/terraform-tencent/schemas/component-uischema-terraform-tencent.yaml
@@ -1,0 +1,2 @@
+- jsonKey: name
+  disable: true

--- a/addons/terraform-ucloud/definitions/ucloud-provider.cue
+++ b/addons/terraform-ucloud/definitions/ucloud-provider.cue
@@ -47,13 +47,11 @@ template: {
 				labels:    l
 			}
 			type: "Opaque"
-					stringData: credentials: strings.Join([
+			stringData: credentials: strings.Join([
 							"privateKey: " + parameter.UCLOUD_PRIVATE_KEY,
-
 							"publicKey: " + parameter.UCLOUD_PUBLIC_KEY,
-
 							"projectID: " + parameter.UCLOUD_PROJECT_ID,
-						], "\n")
+			], "\n")
 		}
 	}
 
@@ -66,13 +64,13 @@ template: {
 	parameter: {
 		//+usage=The name of Terraform Provider for Ucloud Cloud, default is `default`
 		name: *"ucloud" | string
-	//+usage=Get UCLOUD_PRIVATE_KEY per this guide https://docs.ucloud.cn/terraform/quickstart
-	UCLOUD_PRIVATE_KEY: string
-	//+usage=Get UCLOUD_PUBLIC_KEY per this guide https://docs.ucloud.cn/terraform/quickstart
-	UCLOUD_PUBLIC_KEY: string
-	//+usage=Get UCLOUD_PROJECT_ID per this guide https://docs.ucloud.cn/terraform/quickstart
-	UCLOUD_PROJECT_ID: string
-	//+usage=Get UCLOUD_REGION by picking one RegionId from UCloud region list https://docs.ucloud.cn/api/summary/regionlist
-	UCLOUD_REGION: string
-}
+		//+usage=Get UCLOUD_PRIVATE_KEY per this guide https://docs.ucloud.cn/terraform/quickstart
+		UCLOUD_PRIVATE_KEY: string
+		//+usage=Get UCLOUD_PUBLIC_KEY per this guide https://docs.ucloud.cn/terraform/quickstart
+		UCLOUD_PUBLIC_KEY: string
+		//+usage=Get UCLOUD_PROJECT_ID per this guide https://docs.ucloud.cn/terraform/quickstart
+		UCLOUD_PROJECT_ID: string
+		//+usage=Get UCLOUD_REGION by picking one RegionId from UCloud region list https://docs.ucloud.cn/api/summary/regionlist
+		UCLOUD_REGION: string
+	}
 }

--- a/addons/terraform-ucloud/schemas/component-uischema-terraform-ucloud.yaml
+++ b/addons/terraform-ucloud/schemas/component-uischema-terraform-ucloud.yaml
@@ -1,0 +1,2 @@
+- jsonKey: name
+  disable: true

--- a/hack/addons/syn_addon_package.go
+++ b/hack/addons/syn_addon_package.go
@@ -21,28 +21,28 @@ import (
 	"fmt"
 	"net/http"
 	"path/filepath"
-	"sigs.k8s.io/yaml"
 	"time"
 
-	"helm.sh/helm/v3/pkg/chart"
-	"helm.sh/helm/v3/pkg/repo"
+	"sigs.k8s.io/yaml"
+
 	"io/ioutil"
 	"os"
 	"os/exec"
+
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/repo"
 )
 
 type Metadata struct {
-	Name               string              `json:"name" validate:"required"`
-	Version            string              `json:"version"`
-	Description        string              `json:"description"`
-	Icon               string              `json:"icon"`
-	URL                string              `json:"url,omitempty"`
-	Tags               []string            `json:"tags,omitempty"`
-	NeedNamespace      []string            `json:"needNamespace,omitempty"`
-	Invisible          bool                `json:"invisible"`
+	Name          string   `json:"name" validate:"required"`
+	Version       string   `json:"version"`
+	Description   string   `json:"description"`
+	Icon          string   `json:"icon"`
+	URL           string   `json:"url,omitempty"`
+	Tags          []string `json:"tags,omitempty"`
+	NeedNamespace []string `json:"needNamespace,omitempty"`
+	Invisible     bool     `json:"invisible"`
 }
-
-
 
 func main() {
 	dir := os.Args[1]
@@ -60,7 +60,7 @@ func main() {
 
 	originIndex := &repo.IndexFile{}
 
-	body, err := http.Get(repoURL+"/index.yaml")
+	body, err := http.Get(repoURL + "/index.yaml")
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -96,10 +96,10 @@ func main() {
 			entry := repo.ChartVersions{}
 			entry = append(entry, &repo.ChartVersion{Metadata: &chart.Metadata{Name: info.Name(),
 				Version: m.Version, Icon: m.Icon, Keywords: m.Tags, Description: m.Description,
-				Home: m.URL, }, Created: time.Now(), URLs: []string{repoURL+"/"+info.Name()+"-"+m.Version+".tgz"}})
+				Home: m.URL}, Created: time.Now(), URLs: []string{repoURL + "/" + info.Name() + "-" + m.Version + ".tgz"}})
 			entries[info.Name()] = entry
 
-			err = helmSave(dir, info.Name(), info.Name(),m.Version)
+			err = helmSave(dir, info.Name(), info.Name(), m.Version)
 			if err != nil {
 				fmt.Println(err)
 			}
@@ -107,9 +107,8 @@ func main() {
 	}
 	index := repo.IndexFile{APIVersion: "v1", Entries: entries}
 
-
 	index.Merge(originIndex)
-	out,err := yaml.Marshal(index)
+	out, err := yaml.Marshal(index)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -127,7 +126,7 @@ func helmSave(dir, name, addonDir, version string) error {
 	cmd := exec.Command("tar", "zcf", filename, dir+addonDir+"/")
 	cmd.Stdout = &outInfo
 	fmt.Println(cmd.String())
-	if err := cmd.Run(); err != nil{
+	if err := cmd.Run(); err != nil {
 		fmt.Println(outInfo.String())
 		fmt.Println(err)
 		return err


### PR DESCRIPTION
In VelaUX, hide Terraform Provider name (parameter.name) by creating a ui schema.

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>

<!--
Thank you for contributing to OAM workloads!

-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?

<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist

<!--
Please run through the below readiness checklist. The first two items are
relevant to every OAM catalog pull request.
-->

I have:

- [ ] Title of the PR starts with type (e.g. `[Addon]` or `[Trait]`).
- [ ] Updated/Added any relevant [documentation] and [examples].
- [ ] Unit/E2E Tests added.
